### PR TITLE
Ensure training data loaded for experimental model

### DIFF
--- a/train_model.py
+++ b/train_model.py
@@ -54,7 +54,11 @@ def main():
     validation_df = pd.read_parquet(args.validation_data)
 
     if 'train_df' not in locals():
-        raise RuntimeError("train_df must be defined before feature extraction")
+        raise RuntimeError(
+            f"Training data frame 'train_df' is not defined for model type '{args.model_type}'. "
+            f"Expected training data path: {train_data_path}. "
+            "Check if the run_summary.json and its referenced files are correct and accessible."
+        )
 
     logging.info(f"Training {args.model_type} model...")
     logging.info(f"Training data: {train_data_path}")

--- a/train_model.py
+++ b/train_model.py
@@ -43,6 +43,7 @@ def main():
         with open(run_summary["parameters"]["features_json"]) as f:
             original_features = json.load(f)["feature_sets"]["medium"]
         feature_cols = original_features + new_features
+        train_df = pd.read_parquet(train_data_path, columns=feature_cols + [target_col, 'era'])
     else: # control
         train_data_path = run_summary["parameters"]["input_data"]
         target_col = "target" # Assuming standard target for control
@@ -51,6 +52,9 @@ def main():
         train_df = pd.read_parquet(train_data_path, columns=feature_cols + [target_col, 'era'])
 
     validation_df = pd.read_parquet(args.validation_data)
+
+    if 'train_df' not in locals():
+        raise RuntimeError("train_df must be defined before feature extraction")
 
     logging.info(f"Training {args.model_type} model...")
     logging.info(f"Training data: {train_data_path}")


### PR DESCRIPTION
## Summary
- Load training data for experimental model after determining feature columns
- Add check to ensure train_df is defined before feature extraction

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68953f76fc2483289a62e5ff2a030a31