### PR TITLE
Avoid discovery mutation in null hypothesis test

### DIFF
--- a/validation.py
+++ b/validation.py
@@ -25,7 +25,7 @@ def run_null_hypothesis_test(discovery, data_sample, target_col, feature_cols):
         paths = test_disc.find_creative_paths(fv, tv)
         test_disc.update_relationships_from_paths(paths, fv, tv)
 
-    shuffled_relationships = test_disc.get_discovered_relationships(min_strength=0.15)
+    shuffled_relationships = test_disc.get_discovered_relationships(min_strength=MIN_STRENGTH_THRESHOLD)
     if len(shuffled_relationships) > NULL_HYPOTHESIS_RELATIONSHIP_THRESHOLD:
         logging.warning("🚨 OVERFITTING ALERT: meaningful relationships found on shuffled targets")
         return False

--- a/validation.py
+++ b/validation.py
@@ -18,7 +18,7 @@ def run_null_hypothesis_test(discovery, data_sample, target_col, feature_cols):
     rng = np.random.default_rng(42)
     shuffled[target_col] = rng.permutation(shuffled[target_col].values)
 
-    test_rows = shuffled.sample(n=min(500, len(shuffled)), random_state=42)
+    test_rows = shuffled.sample(n=min(NULL_HYPOTHESIS_SAMPLE_SIZE, len(shuffled)), random_state=42)
     for _, row in test_rows.iterrows():
         fv = row[feature_cols].values.astype(float)
         tv = float(row[target_col])

--- a/validation.py
+++ b/validation.py
@@ -15,7 +15,8 @@ def run_null_hypothesis_test(discovery, data_sample, target_col, feature_cols):
     test_disc = copy.deepcopy(discovery)
 
     shuffled = data_sample.copy()
-    shuffled[target_col] = np.random.permutation(shuffled[target_col].values)
+    rng = np.random.default_rng(42)
+    shuffled[target_col] = rng.permutation(shuffled[target_col].values)
 
     test_rows = shuffled.sample(n=min(500, len(shuffled)), random_state=42)
     for _, row in test_rows.iterrows():

--- a/validation.py
+++ b/validation.py
@@ -26,7 +26,7 @@ def run_null_hypothesis_test(discovery, data_sample, target_col, feature_cols):
         test_disc.update_relationships_from_paths(paths, fv, tv)
 
     shuffled_relationships = test_disc.get_discovered_relationships(min_strength=0.15)
-    if len(shuffled_relationships) > 5:
+    if len(shuffled_relationships) > NULL_HYPOTHESIS_RELATIONSHIP_THRESHOLD:
         logging.warning("🚨 OVERFITTING ALERT: meaningful relationships found on shuffled targets")
         return False
     logging.info("✅ Sanity check passed: no significant relationships on shuffled targets")

--- a/validation.py
+++ b/validation.py
@@ -1,0 +1,32 @@
+import logging
+import numpy as np
+import copy
+
+
+def run_null_hypothesis_test(discovery, data_sample, target_col, feature_cols):
+    """Run null hypothesis test with shuffled targets to detect overfitting.
+
+    To avoid contaminating the live discovery state, operate on a deep copy
+    of the discovery object.
+    """
+    logging.info("Running null hypothesis test (shuffled targets)...")
+
+    # work on a deep copy so we don't mutate the live discovery state
+    test_disc = copy.deepcopy(discovery)
+
+    shuffled = data_sample.copy()
+    shuffled[target_col] = np.random.permutation(shuffled[target_col].values)
+
+    test_rows = shuffled.sample(n=min(500, len(shuffled)), random_state=42)
+    for _, row in test_rows.iterrows():
+        fv = row[feature_cols].values.astype(float)
+        tv = float(row[target_col])
+        paths = test_disc.find_creative_paths(fv, tv)
+        test_disc.update_relationships_from_paths(paths, fv, tv)
+
+    shuffled_relationships = test_disc.get_discovered_relationships(min_strength=0.15)
+    if len(shuffled_relationships) > 5:
+        logging.warning("🚨 OVERFITTING ALERT: meaningful relationships found on shuffled targets")
+        return False
+    logging.info("✅ Sanity check passed: no significant relationships on shuffled targets")
+    return True


### PR DESCRIPTION
## Summary
- add null hypothesis testing helper that operates on a deep copy of discovery to prevent state contamination

## Testing
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689558e6c6c88328a2feac1659237720