### PR TITLE
chore: ignore package-lock.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -131,3 +131,5 @@ v5.0/
 pipeline_runs/
 *.log
 node_modules
+
+package-lock.json


### PR DESCRIPTION
## Summary
- ignore package-lock.json files in git

## Testing
- `npm test` *(fails: Missing script: "test")*
- `pytest` *(fails: ModuleNotFoundError: No module named 'python_scripts.experiment')*


------
https://chatgpt.com/codex/tasks/task_e_689765229ef88328997c50cd90b6660f