### PR TITLE
chore: remove unused requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,10 +4,6 @@ pyarrow
 lightgbm
 scikit-learn
 scipy
-streamlit
-graphviz
-streamlit-aggrid
-altair
 fastapi
 uvicorn[standard]
 pydantic


### PR DESCRIPTION
## Summary
- clean up unused dependencies from requirements

## Testing
- `pytest -q` *(fails: No module named 'python_scripts.experiment', No module named 'apply_bootstrap_to_validation')*

------
https://chatgpt.com/codex/tasks/task_e_68976e6d4b708328aba4956fcf1bea69