### PR TITLE
feat(builder): display detailed node status

### DIFF
--- a/web/src/ui/pages/BuilderPage.tsx
+++ b/web/src/ui/pages/BuilderPage.tsx
@@ -235,7 +235,7 @@ export default function BuilderPage(){
                   data: {
                     ...n.data,
                     status: 'running' as NodeStatus,
-                    statusText: 'Era 127/340, Sharpe: 0.847, ETA: 23min',
+                    statusText: 'Running target discovery...',
                   },
                 }
               : n,

--- a/web/src/ui/pages/BuilderPage.tsx
+++ b/web/src/ui/pages/BuilderPage.tsx
@@ -14,8 +14,8 @@ import { ReactFlow,
   Handle,
   Position,
   NodeProps,
-  NodeTypes,
 } from '@xyflow/react'
+import type { NodeTypes } from '@xyflow/react'
 import '@xyflow/react/dist/style.css'
 import ParameterForm from '../components/Wizard/ParameterForm'
 import GlobalPickerModal from '../components/Wizard/GlobalPickerModal'


### PR DESCRIPTION
## Summary
- show detailed status text under each node
- surface status messages in sidebar
- update run logic to include example progress, success, and failure messages

## Testing
- `pytest`
- `cd web && npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_6897b84ca98c8328a32063ecb0d81a1e