### PR TITLE
feat: propagate artifacts downstream

### DIFF
--- a/web/src/ui/pages/BuilderPage.tsx
+++ b/web/src/ui/pages/BuilderPage.tsx
@@ -322,8 +322,8 @@ export default function BuilderPage() {
             if (downstream.includes(n.id) && n.data.kind === 'pathfinding') {
               const cfg = {
                 ...n.data.config,
-                inheritTargetsFrom: src.id,
-                targetsJson: 'target_discovery.json',
+                [INHERIT_TARGETS_FROM_KEY]: src.id,
+                [TARGETS_JSON_KEY]: 'target_discovery.json',
               }
               const status = n.data.status === 'idle' ? 'configured' : n.data.status
               return { ...n, data: { ...n.data, config: cfg, status } }

--- a/web/src/ui/pages/BuilderPage.tsx
+++ b/web/src/ui/pages/BuilderPage.tsx
@@ -271,9 +271,9 @@ function validatePipeline(ns: Node<NodeData>[], es: Edge[]): string[] | null {
 
 export default function BuilderPage() {
   const [nodes, setNodes, onNodesChange] = useNodesState<Node<NodeData>>(
-    ([] as unknown) as Node<NodeData>[]
+    []
   )
-  const [edges, setEdges, onEdgesChange] = useEdgesState<Edge>(([] as unknown) as Edge[])
+  const [edges, setEdges, onEdgesChange] = useEdgesState<Edge>([])
   const [selection, setSelection] = useState<Node<NodeData> | null>(null)
   const [progress, setProgress] = useState({ total: 0, completed: 0 })
   const idRef = useRef(1)

--- a/web/src/ui/pages/BuilderPage.tsx
+++ b/web/src/ui/pages/BuilderPage.tsx
@@ -336,8 +336,8 @@ export default function BuilderPage() {
             if (downstream.includes(n.id) && n.data.kind === 'feature-engineering') {
               const cfg = {
                 ...n.data.config,
-                inheritRelationshipsFrom: src.id,
-                relationshipsJson: 'relationships.json',
+                [INHERIT_RELATIONSHIPS_FROM]: src.id,
+                [RELATIONSHIPS_JSON]: 'relationships.json',
               }
               const status = n.data.status === 'idle' ? 'configured' : n.data.status
               return { ...n, data: { ...n.data, config: cfg, status } }


### PR DESCRIPTION
## Summary
- add propagateArtifacts helper to inject upstream artifacts into connected nodes
- trigger artifact propagation after Target Discovery runs complete

## Testing
- `npm --prefix web test` *(fails: Missing script "test")*
- `npm --prefix web run build`


------
https://chatgpt.com/codex/tasks/task_e_6897b83650888328b32fbb3699bcf00d