### PR TITLE
feat(builder): validate node connections

### DIFF
--- a/web/src/ui/app.css
+++ b/web/src/ui/app.css
@@ -73,3 +73,7 @@ button{font:inherit}
 /* Links */
 a{color:#cbd5ff}
 a:hover{color:#e0e6ff}
+
+/* React Flow connection feedback */
+.react-flow__connection.valid .react-flow__connection-path{stroke:#16a34a}
+.react-flow__connection.invalid .react-flow__connection-path{stroke:#dc2626}

--- a/web/src/ui/pages/BuilderPage.tsx
+++ b/web/src/ui/pages/BuilderPage.tsx
@@ -54,11 +54,10 @@ function StatusDot({ s }: { s: NodeStatus }){
 
 function NodeCard({ data }: NodeProps<Node<NodeData>>){
   const { getNode } = useReactFlow<Node<NodeData>>()
-  const isValidConnection = useCallback((conn: Connection) => {
-    const src = getNode(conn.source as string)
-    const tgt = getNode(conn.target as string)
-    return !!(src && tgt && allowsConnection(src.data.kind, tgt.data.kind))
-  }, [getNode])
+  const isValidConnection = useCallback(
+    (conn: Connection) => isConnectionValid(getNode, conn),
+    [getNode]
+  )
 
   const icon = data.kind === 'data-source' ? '📁'
     : data.kind === 'target-discovery' ? '🎯'


### PR DESCRIPTION
## Summary
- add connection validation and color-coded feedback for the builder canvas
- prevent invalid edges and highlight valid links in green

## Testing
- `pytest`
- `cd web && npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_6897b818751483289602ecac6ca408ef