### PR TITLE
Add node-specific config panels for builder

### DIFF
--- a/web/src/ui/components/NodeConfig/FeatureEngineeringConfig.tsx
+++ b/web/src/ui/components/NodeConfig/FeatureEngineeringConfig.tsx
@@ -1,0 +1,51 @@
+import * as React from 'react'
+
+type Props = {
+  cfg: any
+  onChange: (patch: any) => void
+}
+
+export default function FeatureEngineeringConfig({ cfg, onChange }: Props) {
+  return (
+    <div className="flex flex-col gap-4">
+      <div className="text-xs text-slate-400">Inherits relationships.json from upstream.</div>
+
+      <div className="rounded-md border border-slate-700 bg-slate-900 p-3">
+        <label className="flex flex-col gap-2">
+          <span className="text-sm font-medium">Max new features</span>
+          <input
+            className="input"
+            type="number"
+            value={cfg.maxNew || 0}
+            onChange={(e) => onChange({ maxNew: parseInt(e.target.value || '0', 10) })}
+          />
+        </label>
+      </div>
+
+      <div className="rounded-md border border-slate-700 bg-slate-900 p-3">
+        <label className="flex flex-col gap-2">
+          <span className="text-sm font-medium">Generation strategy</span>
+          <input
+            className="input"
+            type="text"
+            value={cfg.strategy || ''}
+            onChange={(e) => onChange({ strategy: e.target.value })}
+          />
+        </label>
+      </div>
+
+      <div className="rounded-md border border-slate-700 bg-slate-900 p-3">
+        <label className="flex flex-col gap-2">
+          <span className="text-sm font-medium">Naming pattern</span>
+          <input
+            className="input"
+            type="text"
+            value={cfg.naming || ''}
+            onChange={(e) => onChange({ naming: e.target.value })}
+          />
+        </label>
+      </div>
+    </div>
+  )
+}
+

--- a/web/src/ui/components/NodeConfig/PathfindingConfig.tsx
+++ b/web/src/ui/components/NodeConfig/PathfindingConfig.tsx
@@ -1,0 +1,61 @@
+import * as React from 'react'
+
+type Props = {
+  cfg: any
+  onChange: (patch: any) => void
+}
+
+export default function PathfindingConfig({ cfg, onChange }: Props) {
+  return (
+    <div className="flex flex-col gap-4">
+      <div className="text-xs text-slate-400">Uses target_discovery.json from upstream.</div>
+
+      <div className="rounded-md border border-slate-700 bg-slate-900 p-3">
+        <label className="flex items-center gap-2">
+          <input
+            type="checkbox"
+            checked={cfg.yolo || false}
+            onChange={(e) => onChange({ yolo: e.target.checked })}
+          />
+          <span className="text-sm font-medium">YOLO mode</span>
+        </label>
+      </div>
+
+      <div className="rounded-md border border-slate-700 bg-slate-900 p-3">
+        <label className="flex flex-col gap-2">
+          <span className="text-sm font-medium">Feature limit</span>
+          <input
+            className="input"
+            type="number"
+            value={cfg.featureLimit || 0}
+            onChange={(e) => onChange({ featureLimit: parseInt(e.target.value || '0', 10) })}
+          />
+        </label>
+      </div>
+
+      <div className="rounded-md border border-slate-700 bg-slate-900 p-3">
+        <label className="flex items-center gap-2">
+          <input
+            type="checkbox"
+            checked={cfg.debug || false}
+            onChange={(e) => onChange({ debug: e.target.checked })}
+          />
+          <span className="text-sm font-medium">Debug</span>
+        </label>
+      </div>
+
+      <div className="rounded-md border border-slate-700 bg-slate-900 p-3">
+        <label className="flex flex-col gap-2">
+          <span className="text-sm font-medium">Relationship count</span>
+          <input
+            className="input"
+            type="number"
+            value={cfg.relationships || 0}
+            onChange={(e) => onChange({ relationships: parseInt(e.target.value || '0', 10) })}
+          />
+        </label>
+      </div>
+    </div>
+  )
+}
+

--- a/web/src/ui/components/NodeConfig/TargetDiscoveryConfig.tsx
+++ b/web/src/ui/components/NodeConfig/TargetDiscoveryConfig.tsx
@@ -1,0 +1,95 @@
+import * as React from 'react'
+import GlobalPickerModal from '../Wizard/GlobalPickerModal'
+
+type Props = {
+  cfg: any
+  onChange: (patch: any) => void
+}
+
+export default function TargetDiscoveryConfig({ cfg, onChange }: Props) {
+  const [open, setOpen] = React.useState<null | 'parquet'>(null)
+
+  return (
+    <div className="flex flex-col gap-4">
+      <div className="rounded-md border border-slate-700 bg-slate-900 p-3">
+        <label className="flex flex-col gap-2">
+          <span className="text-sm font-medium">Input data</span>
+          <button
+            type="button"
+            onClick={() => setOpen('parquet')}
+            title={cfg.inputData}
+            className="w-full truncate rounded-md border border-slate-600 bg-slate-800 px-3 py-2 text-left hover:border-slate-500 focus:outline-none focus:ring-2 focus:ring-blue-600"
+          >
+            {cfg.inputData || '(select data parquet)'}
+          </button>
+          <span className="text-xs text-slate-400">Parquet file containing the training rows.</span>
+        </label>
+      </div>
+
+      <div className="rounded-md border border-slate-700 bg-slate-900 p-3">
+        <label className="flex items-center gap-2">
+          <input
+            type="checkbox"
+            checked={cfg.smoke || false}
+            onChange={(e) => onChange({ smoke: e.target.checked })}
+          />
+          <span className="text-sm font-medium">Smoke mode</span>
+        </label>
+        {cfg.smoke && (
+          <div className="mt-2 grid grid-cols-1 gap-4 md:grid-cols-2">
+            <label className="flex flex-col gap-2">
+              <span className="text-sm">Era limit</span>
+              <input
+                className="input"
+                type="number"
+                value={cfg.smokeEras || 0}
+                onChange={(e) => onChange({ smokeEras: parseInt(e.target.value || '0', 10) })}
+              />
+            </label>
+            <label className="flex flex-col gap-2">
+              <span className="text-sm">Row limit</span>
+              <input
+                className="input"
+                type="number"
+                value={cfg.smokeRows || 0}
+                onChange={(e) => onChange({ smokeRows: parseInt(e.target.value || '0', 10) })}
+              />
+            </label>
+          </div>
+        )}
+      </div>
+
+      <div className="rounded-md border border-slate-700 bg-slate-900 p-3">
+        <label className="flex items-center gap-2">
+          <input
+            type="checkbox"
+            checked={cfg.walkForward || false}
+            onChange={(e) => onChange({ walkForward: e.target.checked })}
+          />
+          <span className="text-sm font-medium">Walk-forward validation</span>
+        </label>
+      </div>
+
+      <div className="rounded-md border border-slate-700 bg-slate-900 p-3">
+        <label className="flex flex-col gap-2">
+          <span className="text-sm font-medium">Seed</span>
+          <input
+            className="input"
+            type="number"
+            value={cfg.seed || 0}
+            onChange={(e) => onChange({ seed: parseInt(e.target.value || '0', 10) })}
+          />
+        </label>
+      </div>
+
+      {open && (
+        <GlobalPickerModal
+          mode={open}
+          onSelect={(v) => onChange({ inputData: v })}
+          onClose={() => setOpen(null)}
+        />
+      )}
+    </div>
+  )
+}
+

--- a/web/src/ui/pages/BuilderPage.tsx
+++ b/web/src/ui/pages/BuilderPage.tsx
@@ -14,10 +14,12 @@ import { ReactFlow,
   Handle,
   Position,
   NodeProps,
+  NodeTypes,
 } from '@xyflow/react'
 import '@xyflow/react/dist/style.css'
-import ParameterForm from '../components/Wizard/ParameterForm'
-import GlobalPickerModal from '../components/Wizard/GlobalPickerModal'
+import TargetDiscoveryConfig from '../components/NodeConfig/TargetDiscoveryConfig'
+import PathfindingConfig from '../components/NodeConfig/PathfindingConfig'
+import FeatureEngineeringConfig from '../components/NodeConfig/FeatureEngineeringConfig'
 import { jpost } from '../lib/api'
 
 // Types
@@ -67,7 +69,7 @@ function NodeCard({ data }: NodeProps<Node<NodeData>>){
 
 const nodeTypes: NodeTypes = { default: NodeCard }
 
-// Sidebar for configuration (reuses ParameterForm for now)
+// Sidebar for configuration (node-specific panels)
 function Sidebar({
   selection,
   onUpdate,
@@ -122,20 +124,18 @@ function Sidebar({
         <div className="mt-1 text-xs text-slate-400">Status: {d.status}</div>
       </div>
       <div className="flex-1 overflow-auto p-3">
-        {/* For Phase 1 we reuse ParameterForm directly. Later this will branch by kind. */}
-        <ParameterForm
-          inputData={cfg.inputData} setInputData={(v)=>updateData({ inputData: v })}
-          featuresJson={cfg.featuresJson} setFeaturesJson={(v)=>updateData({ featuresJson: v })}
-          runName={cfg.runName} setRunName={(v)=>updateData({ runName: v })}
-          maxNew={cfg.maxNew} setMaxNew={(v)=>updateData({ maxNew: v })}
-          disablePF={cfg.disablePF} setDisablePF={(v)=>updateData({ disablePF: v })}
-          pretty={cfg.pretty} setPretty={(v)=>updateData({ pretty: v })}
-          smoke={cfg.smoke} setSmoke={(v)=>updateData({ smoke: v })}
-          smokeEras={cfg.smokeEras} setSmokeEras={(v)=>updateData({ smokeEras: v })}
-          smokeRows={cfg.smokeRows} setSmokeRows={(v)=>updateData({ smokeRows: v })}
-          smokeFeat={cfg.smokeFeat} setSmokeFeat={(v)=>updateData({ smokeFeat: v })}
-          seed={cfg.seed} setSeed={(v)=>updateData({ seed: v })}
-        />
+        {d.kind === 'target-discovery' && (
+          <TargetDiscoveryConfig cfg={cfg} onChange={updateData} />
+        )}
+        {d.kind === 'pathfinding' && (
+          <PathfindingConfig cfg={cfg} onChange={updateData} />
+        )}
+        {d.kind === 'feature-engineering' && (
+          <FeatureEngineeringConfig cfg={cfg} onChange={updateData} />
+        )}
+        {d.kind !== 'target-discovery' && d.kind !== 'pathfinding' && d.kind !== 'feature-engineering' && (
+          <div className="text-sm text-slate-300">No configuration available.</div>
+        )}
       </div>
       <div className="border-t border-slate-700 p-3">
         <div className="row-between">


### PR DESCRIPTION
## Summary
- introduce TargetDiscoveryConfig, PathfindingConfig, and FeatureEngineeringConfig components
- swap builder sidebar to render node-specific config panels

## Testing
- `npm run build`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6897b7f3b8c083288bc1b4d198a507a4