### PR TITLE
feat(ui): orchestrate pipeline DAG

### DIFF
--- a/web/src/ui/pages/BuilderPage.tsx
+++ b/web/src/ui/pages/BuilderPage.tsx
@@ -14,8 +14,8 @@ import { ReactFlow,
   Handle,
   Position,
   NodeProps,
-  NodeTypes,
 } from '@xyflow/react'
+import type { NodeTypes } from '@xyflow/react'
 import '@xyflow/react/dist/style.css'
 import ParameterForm from '../components/Wizard/ParameterForm'
 import GlobalPickerModal from '../components/Wizard/GlobalPickerModal'


### PR DESCRIPTION
## Summary
- add topological sort and validation utilities for builder page
- run nodes sequentially in dependency order with status updates and progress bar

## Testing
- `npm --prefix web run build`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6897b8e25cfc8328a8ae8eea1507c082