### PR TITLE
feat: add lane auto-arrange and visuals

### DIFF
--- a/web/src/ui/components/Flow/PipelineToolbar.tsx
+++ b/web/src/ui/components/Flow/PipelineToolbar.tsx
@@ -3,10 +3,11 @@ import React from 'react'
 type Props = {
   onRunPipeline: () => void
   onClear: () => void
+  onAutoArrange: () => void
   progress: { total: number; completed: number }
 }
 
-export default function PipelineToolbar({ onRunPipeline, onClear, progress }: Props) {
+export default function PipelineToolbar({ onRunPipeline, onClear, onAutoArrange, progress }: Props) {
   const pct = progress.total ? Math.round((progress.completed / progress.total) * 100) : 0
   return (
     <div className="flex items-center gap-2 border-b border-slate-700 bg-slate-900/60 p-2">
@@ -15,6 +16,9 @@ export default function PipelineToolbar({ onRunPipeline, onClear, progress }: Pr
       </button>
       <button className="btn" onClick={onClear}>
         Clear
+      </button>
+      <button className="btn" onClick={onAutoArrange}>
+        Auto-arrange to lanes
       </button>
       {progress.total > 0 && (
         <div className="flex items-center gap-2 flex-1">

--- a/web/src/ui/pages/BuilderPage.module.css
+++ b/web/src/ui/pages/BuilderPage.module.css
@@ -1,1 +1,1 @@
-.laneGrid{position:absolute;inset:0;pointer-events:none;background-image:repeating-linear-gradient(to right,rgba(148,163,184,.25) 0,rgba(148,163,184,.25) 1px,transparent 1px,transparent 260px);background-position:80px 0}
+.laneGrid{position:absolute;inset:0;pointer-events:none;background-image:repeating-linear-gradient(to right,rgba(148,163,184,.08) 0,rgba(148,163,184,.08) 260px,transparent 260px,transparent 520px),repeating-linear-gradient(to right,rgba(148,163,184,.25) 0,rgba(148,163,184,.25) 1px,transparent 1px,transparent 260px);background-position:80px 0}

--- a/web/src/ui/pages/BuilderPage.tsx
+++ b/web/src/ui/pages/BuilderPage.tsx
@@ -385,6 +385,15 @@ export default function BuilderPage() {
     setSelection(null)
   }, [setNodes, setEdges])
 
+  const onAutoArrange = useCallback(() => {
+    setNodes(ns =>
+      ns.map(n => {
+        const idx = laneIndexById.get(n.id)
+        return idx != null ? { ...n, position: { x: snapXForLane(idx), y: n.position.y } } : n
+      })
+    )
+  }, [setNodes, laneIndexById])
+
   // DnD handlers
   const onDragOver = useCallback((event: React.DragEvent) => {
     event.preventDefault()
@@ -414,7 +423,7 @@ export default function BuilderPage() {
         <NodePalette onAdd={addNode} />
       </div>
       <div className="flex min-w-0 flex-1 flex-col rounded-lg border border-slate-700 bg-slate-900/40">
-        <PipelineToolbar onRunPipeline={onRunPipeline} onClear={onClear} progress={progress} />
+        <PipelineToolbar onRunPipeline={onRunPipeline} onClear={onClear} onAutoArrange={onAutoArrange} progress={progress} />
         <div className="relative min-h-0 flex-1" ref={wrapperRef}>
           <ReactFlow<Node<NodeData>, Edge>
             nodes={nodes}


### PR DESCRIPTION
## Summary
- add Auto-arrange to lanes button in builder toolbar
- implement auto arrange logic to snap nodes to lane positions
- enhance lane grid overlay with alternating shading for clearer lane separation

## Testing
- `pytest`
- `npm test` (fails: Missing script "test")
- `cd web && npm test` (fails: Missing script "test")
- `cd web && npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6897daaa9bf48328aacdc22af921744d