### PR TITLE
feat: expand pipeline node types

### DIFF
--- a/web/src/ui/components/Flow/NodeCard.tsx
+++ b/web/src/ui/components/Flow/NodeCard.tsx
@@ -28,6 +28,12 @@ export default function NodeCard(props: NodeProps<NodeData>) {
       ? '🔍'
       : data.kind === 'feature-engineering'
       ? '⚗️'
+      : data.kind === 'transform'
+      ? '🔄'
+      : data.kind === 'train'
+      ? '🏋️'
+      : data.kind === 'validate'
+      ? '✅'
       : '📊'
 
   // helper: style per handle type

--- a/web/src/ui/components/Flow/NodePalette.tsx
+++ b/web/src/ui/components/Flow/NodePalette.tsx
@@ -11,6 +11,9 @@ export default function NodePalette({ onAdd }: Props) {
     { kind: 'target-discovery', label: 'Targets', icon: '🎯' },
     { kind: 'pathfinding', label: 'Pathfind', icon: '🔍' },
     { kind: 'feature-engineering', label: 'Features', icon: '⚗️' },
+    { kind: 'transform', label: 'Transform', icon: '🔄' },
+    { kind: 'train', label: 'Train', icon: '🏋️' },
+    { kind: 'validate', label: 'Validate', icon: '✅' },
     { kind: 'output', label: 'Output', icon: '📊' },
   ]
   return (

--- a/web/src/ui/components/Flow/Sidebar.tsx
+++ b/web/src/ui/components/Flow/Sidebar.tsx
@@ -23,34 +23,6 @@ function InputOutputSection({ selection, edges }: { selection: Node<NodeData>; e
   if (!selection) return null
   const constraints = NodeConstraints[selection.data.kind]
   const panelConfig = NodePanelConfigs[selection.data.kind]
-  const styleFor = (t: PayloadType, ghost = false): React.CSSProperties => {
-    const base: React.CSSProperties = {
-      background: HandleTypes[t].color,
-      border: `2px solid ${HandleTypes[t].color}`,
-      width: 10,
-      height: 10,
-      opacity: ghost ? 0.5 : 1,
-    }
-    switch (HandleTypes[t].shape) {
-      case 'circle':
-        base.borderRadius = 999
-        break
-      case 'square':
-        base.borderRadius = 2
-        break
-      case 'diamond':
-        base.transform = 'rotate(45deg)'
-        base.borderRadius = 2
-        break
-      case 'star':
-        base.clipPath = 'polygon(50% 0%, 61% 35%, 98% 35%, 68% 57%, 79% 91%, 50% 70%, 21% 91%, 32% 57%, 2% 35%, 39% 35%)'
-        break
-      case 'triangle':
-        base.clipPath = 'polygon(50% 0%, 0% 100%, 100% 100%)'
-        break
-    }
-    return base
-  }
   return (
     <div className="space-y-4">
       {constraints.inputs.length > 0 && (

--- a/web/src/ui/components/Flow/node-spec.ts
+++ b/web/src/ui/components/Flow/node-spec.ts
@@ -37,7 +37,7 @@ export const NodeConstraints: Record<
     outputs: [{ id: "out-parquet", type: "PARQUET", label: "train.parquet" }],
     output: { id: "out-parquet", type: "PARQUET", label: "train.parquet" },
     description: "Provides the raw training parquet to downstream nodes.",
-    canConnectTo: ["target-discovery", "pathfinding", "feature-engineering"],
+    canConnectTo: ["target-discovery", "pathfinding", "feature-engineering", "transform"],
   },
   "target-discovery": {
     maxInputs: 1,
@@ -78,7 +78,47 @@ export const NodeConstraints: Record<
     ],
     output: { id: "out-enhanced", type: "ENHANCED_DATA", label: "enhanced.parquet" },
     description: "Generates engineered features using relationships; outputs enhanced.parquet.",
-    canConnectTo: ["output"],
+    canConnectTo: ["train", "validate", "output"],
+  },
+  transform: {
+    maxInputs: 1,
+    maxOutputs: 1,
+    inputs: [
+      { id: "in-parquet", type: "PARQUET", label: "input.parquet", required: true },
+    ],
+    outputs: [
+      { id: "out-enhanced", type: "ENHANCED_DATA", label: "transformed.parquet" },
+    ],
+    output: { id: "out-enhanced", type: "ENHANCED_DATA", label: "transformed.parquet" },
+    description: "Applies simple data transformations and emits transformed.parquet.",
+    canConnectTo: ["train", "validate", "output"],
+  },
+  train: {
+    maxInputs: 1,
+    maxOutputs: 1,
+    inputs: [
+      { id: "in-enhanced", type: "ENHANCED_DATA", label: "enhanced.parquet", required: true },
+    ],
+    outputs: [
+      { id: "out-model", type: "JSON_ARTIFACT", label: "model.json" },
+    ],
+    output: { id: "out-model", type: "JSON_ARTIFACT", label: "model.json" },
+    description: "Trains a model from enhanced.parquet and outputs model.json.",
+    canConnectTo: ["validate"],
+  },
+  validate: {
+    maxInputs: 2,
+    maxOutputs: 1,
+    inputs: [
+      { id: "in-enhanced", type: "ENHANCED_DATA", label: "enhanced.parquet", required: true },
+      { id: "in-model", type: "JSON_ARTIFACT", label: "model.json", required: true },
+    ],
+    outputs: [
+      { id: "out-report", type: "FINAL_OUTPUT", label: "report.json" },
+    ],
+    output: { id: "out-report", type: "FINAL_OUTPUT", label: "report.json" },
+    description: "Validates a trained model and produces a report.json.",
+    canConnectTo: [],
   },
   output: {
     maxInputs: 1,
@@ -118,6 +158,21 @@ export const NodePanelConfigs: Record<
       'Requires relationships.json describing feature relationships.',
     ],
     outputs: ['Emits enhanced.parquet containing engineered features.'],
+  },
+  transform: {
+    inputs: ['Consumes input.parquet to apply transformations.'],
+    outputs: ['Emits transformed.parquet with applied transforms.'],
+  },
+  train: {
+    inputs: ['Needs enhanced.parquet containing features.'],
+    outputs: ['Produces model.json capturing the trained model.'],
+  },
+  validate: {
+    inputs: [
+      'Requires enhanced.parquet for evaluation.',
+      'Consumes model.json from training.',
+    ],
+    outputs: ['Emits report.json with validation metrics.'],
   },
   output: {
     inputs: ['Consumes enhanced.parquet to export or visualize results.'],

--- a/web/src/ui/components/Flow/panels/TrainPanel.tsx
+++ b/web/src/ui/components/Flow/panels/TrainPanel.tsx
@@ -1,7 +1,12 @@
 import React from 'react'
 
+interface TrainConfig {
+  learningRate?: number
+  epochs?: number
+}
+
 type Props = {
-  cfg: any
+  cfg: TrainConfig
   updateData: (patch: any) => void
 }
 

--- a/web/src/ui/components/Flow/panels/TrainPanel.tsx
+++ b/web/src/ui/components/Flow/panels/TrainPanel.tsx
@@ -1,0 +1,32 @@
+import React from 'react'
+
+type Props = {
+  cfg: any
+  updateData: (patch: any) => void
+}
+
+export default function TrainPanel({ cfg, updateData }: Props) {
+  return (
+    <div className="flex flex-col gap-4">
+      <label className="flex flex-col gap-1">
+        <span className="text-sm text-slate-300">Learning Rate</span>
+        <input
+          className="input text-sm"
+          type="number"
+          step="0.01"
+          value={cfg.learningRate || 0.1}
+          onChange={e => updateData({ learningRate: parseFloat(e.target.value || '0.1') })}
+        />
+      </label>
+      <label className="flex flex-col gap-1">
+        <span className="text-sm text-slate-300">Epochs</span>
+        <input
+          className="input text-sm"
+          type="number"
+          value={cfg.epochs || 10}
+          onChange={e => updateData({ epochs: parseInt(e.target.value || '10', 10) })}
+        />
+      </label>
+    </div>
+  )
+}

--- a/web/src/ui/components/Flow/panels/TransformPanel.tsx
+++ b/web/src/ui/components/Flow/panels/TransformPanel.tsx
@@ -1,7 +1,11 @@
 import React from 'react'
 
+interface TransformConfig {
+  script?: string
+}
+
 type Props = {
-  cfg: any
+  cfg: TransformConfig
   updateData: (patch: any) => void
 }
 

--- a/web/src/ui/components/Flow/panels/TransformPanel.tsx
+++ b/web/src/ui/components/Flow/panels/TransformPanel.tsx
@@ -1,0 +1,23 @@
+import React from 'react'
+
+type Props = {
+  cfg: any
+  updateData: (patch: any) => void
+}
+
+export default function TransformPanel({ cfg, updateData }: Props) {
+  return (
+    <div className="flex flex-col gap-4">
+      <label className="flex flex-col gap-1">
+        <span className="text-sm text-slate-300">Transform Script</span>
+        <textarea
+          className="input text-sm"
+          rows={3}
+          value={cfg.script || ''}
+          onChange={e => updateData({ script: e.target.value })}
+          placeholder="e.g., normalize features"
+        />
+      </label>
+    </div>
+  )
+}

--- a/web/src/ui/components/Flow/panels/ValidatePanel.tsx
+++ b/web/src/ui/components/Flow/panels/ValidatePanel.tsx
@@ -1,0 +1,34 @@
+import React from 'react'
+
+type Props = {
+  cfg: any
+  updateData: (patch: any) => void
+}
+
+export default function ValidatePanel({ cfg, updateData }: Props) {
+  return (
+    <div className="flex flex-col gap-4">
+      <label className="flex flex-col gap-1">
+        <span className="text-sm text-slate-300">Validation Split</span>
+        <input
+          className="input text-sm"
+          type="number"
+          step="0.1"
+          min="0.1"
+          max="1"
+          value={cfg.split || 0.2}
+          onChange={e => updateData({ split: parseFloat(e.target.value || '0.2') })}
+        />
+      </label>
+      <label className="flex flex-col gap-1">
+        <span className="text-sm text-slate-300">Metrics</span>
+        <input
+          className="input text-sm"
+          value={cfg.metrics || ''}
+          onChange={e => updateData({ metrics: e.target.value })}
+          placeholder="accuracy, auc"
+        />
+      </label>
+    </div>
+  )
+}

--- a/web/src/ui/components/Flow/panels/ValidatePanel.tsx
+++ b/web/src/ui/components/Flow/panels/ValidatePanel.tsx
@@ -1,7 +1,12 @@
 import React from 'react'
 
+interface ValidationConfig {
+  split?: number
+  metrics?: string
+}
+
 type Props = {
-  cfg: any
+  cfg: ValidationConfig
   updateData: (patch: any) => void
 }
 

--- a/web/src/ui/components/Flow/types.ts
+++ b/web/src/ui/components/Flow/types.ts
@@ -4,6 +4,9 @@ export type NodeKind =
   | "target-discovery"
   | "pathfinding"
   | "feature-engineering"
+  | "transform"
+  | "train"
+  | "validate"
   | "output";
 
 export type NodeStatus =

--- a/web/src/ui/pages/BuilderPage.tsx
+++ b/web/src/ui/pages/BuilderPage.tsx
@@ -86,6 +86,12 @@ export default function BuilderPage() {
           ? 'Pathfinding'
           : kind === 'feature-engineering'
           ? 'Feature Engineering'
+          : kind === 'transform'
+          ? 'Transform'
+          : kind === 'train'
+          ? 'Train'
+          : kind === 'validate'
+          ? 'Validate'
           : 'Output'
   const n: Node<NodeData> = {
         id,
@@ -337,6 +343,20 @@ export default function BuilderPage() {
     setSelection(null)
   }, [setNodes, setEdges])
 
+  const deleteSelection = useCallback(() => {
+    if (!selection) return
+    setNodes(ns => ns.filter(n => n.id !== selection.id))
+    setEdges(es => es.filter(e => e.source !== selection.id && e.target !== selection.id))
+    setSelection(null)
+  }, [selection, setNodes, setEdges])
+
+  const onEdgeDoubleClick = useCallback(
+    (_: React.MouseEvent, edge: Edge) => {
+      setEdges(es => es.filter(e => e.id !== edge.id))
+    },
+    [setEdges]
+  )
+
   
 
   // DnD handlers
@@ -370,6 +390,11 @@ export default function BuilderPage() {
             onNodesChange={onNodesChange}
             onEdgesChange={onEdgesChange}
             onConnect={onConnect}
+            onEdgeDoubleClick={onEdgeDoubleClick}
+            deleteKeyCode={[ 'Backspace', 'Delete' ]}
+            onNodesDelete={nd => {
+              if (selection && nd.some(n => n.id === selection.id)) setSelection(null)
+            }}
             nodeTypes={nodeTypes}
             onNodeClick={(_evt: React.MouseEvent, n: Node<NodeData>) => setSelection(n)}
             onInit={setRf}
@@ -385,9 +410,15 @@ export default function BuilderPage() {
           
         </div>
       </div>
-      <div className="w-[420px] shrink-0 rounded-lg border border-slate-700 bg-slate-900/60">
-        <Sidebar selection={selection} onUpdate={onUpdateSelection} onRun={onRunNode} />
-      </div>
+        <div className="w-[420px] shrink-0 rounded-lg border border-slate-700 bg-slate-900/60">
+          <Sidebar
+            selection={selection}
+            edges={edges}
+            onUpdate={onUpdateSelection}
+            onRun={onRunNode}
+            onDelete={deleteSelection}
+          />
+        </div>
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- add transform, train and validate nodes with simple config panels
- mirror handle shapes/colors in sidebar and flag missing required inputs
- support node and edge deletion via delete button or keypress

## Testing
- `npm test` *(fails: Missing script)*
- `npm test --prefix web` *(fails: Missing script)*
- `npm run build --prefix web`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6898c43883288328b128de09eefd0e16