### PR TITLE
fix: create test_data directory when generating synthetic data

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -96,6 +96,12 @@ import os
 
 print('Generating synthetic test datasets...')
 
+# Ensure the test_data directory exists in case the calling
+# environment didn't create it beforehand. Without this check,
+# attempting to write the parquet files below would raise an
+# OSError when the directory is missing.
+os.makedirs('test_data', exist_ok=True)
+
 # Small dataset for unit tests
 np.random.seed(42)
 n_rows_small = 5000


### PR DESCRIPTION
## Summary
- ensure setup script creates test_data directory before writing synthetic parquet files

## Testing
- `pytest pipeline/tests/test_production_readiness.py::TestDataFile::test_dataframe_memory_usage -vv` *(fails: ModuleNotFoundError: No module named 'pandas')*


------
https://chatgpt.com/codex/tasks/task_e_68b26da0b42c8328af84e336e59efc79