### PR TITLE
Handle missing test_data directory for synthetic data

### DIFF
--- a/numerai_minimal/CI_CD_README.md
+++ b/numerai_minimal/CI_CD_README.md
@@ -200,6 +200,7 @@ python -c "
 import pandas as pd
 import numpy as np
 import json
+from pathlib import Path
 
 # Generate test dataset
 np.random.seed(42)
@@ -213,6 +214,7 @@ for i in range(10):
     data[f'target_{i}'] = np.random.randn(n_rows) * 0.05
 
 df = pd.DataFrame(data)
+Path('test_data').mkdir(exist_ok=True)
 df.to_parquet('test_data/train_production.parquet')
 "
 ```


### PR DESCRIPTION
## Summary
- Create `test_data` directory with placeholder file so synthetic data can be saved
- Update CI/CD README example to create the directory before writing parquet files

## Testing
- `pytest pipeline/tests -q`


------
https://chatgpt.com/codex/tasks/task_e_68b289c1386c8328b87e5ec55fd99619